### PR TITLE
fix: resolve Firebase deployment URL retrieval error

### DIFF
--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -25,8 +25,6 @@ runs:
         ls -la
         echo "📦 dist directory contents:"
         ls -la dist/ || echo "dist directory not found"
-        echo "📦 dist directory contents:"
-        ls -la dist/ || echo "dist directory not found"
         
         firebase deploy --only hosting --project ${{ inputs.project-id }}
         
@@ -39,4 +37,5 @@ runs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/serviceAccountKey.json
       run: |
         echo "🌐 Getting deployment URL..."
-        firebase hosting:channel:list --json | jq -r '.result.channels[0].url // "Deployment URL not available"'
+        echo "Production site deployed to: https://${{ inputs.project-id }}.web.app"
+        echo "Firebase Console: https://console.firebase.google.com/project/${{ inputs.project-id }}/hosting"


### PR DESCRIPTION
- Fix "Get Deployment URL" step in deploy-firebase-hosting action
- Replace failing firebase hosting:channel:list command with static URL output
- Remove duplicate debug output lines for cleaner logs
- Ensure production deployments complete successfully without exit code 2

This resolves the issue where production Firebase deployments appeared to fail due to a cosmetic error in the final step, even though hosting deployment was successful. Now deployments complete cleanly and show correct URLs.